### PR TITLE
Remove ignore option and functionality

### DIFF
--- a/lib/bundler/audit/cli.rb
+++ b/lib/bundler/audit/cli.rb
@@ -32,7 +32,6 @@ module Bundler
       desc 'check', 'Checks the Gemfile.lock for insecure dependencies'
       method_option :quiet, :type => :boolean, :aliases => '-q'
       method_option :verbose, :type => :boolean, :aliases => '-v'
-      method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
 
       def check
@@ -41,7 +40,7 @@ module Bundler
         scanner    = Scanner.new
         vulnerable = false
 
-        scanner.scan(:ignore => options.ignore) do |result|
+        scanner.scan do |result|
           vulnerable = true
 
           case result

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -31,24 +31,6 @@ Solution: remove or disable this gem until a patch is available!)+/
     end
   end
 
-  context "when auditing a bundle with ignored gems" do
-    let(:bundle)    { 'unpatched_gems' }
-    let(:directory) { File.join('spec','bundle',bundle) }
-
-    let(:command) do
-      File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundler-leak -i OSVDB-89026'))
-    end
-
-    subject do
-      Dir.chdir(directory) { sh(command, :fail => true) }
-    end
-
-    it "should not print advisory information for ignored gem" do
-      # TODO we don't use OSVDB ids in rubymem, modify this expectation according to rubymem
-      expect(subject).not_to include("OSVDB-89026")
-    end
-  end
-
   context "when auditing a secure bundle" do
     let(:bundle)    { 'secure' }
     let(:directory) { File.join('spec','bundle',bundle) }


### PR DESCRIPTION
Bundler-leak should not have an ignore flag that ignores gems to scan based on a security vulnerability id