### PR TITLE
Fix bundler-leak update

### DIFF
--- a/lib/bundler/plumber/database.rb
+++ b/lib/bundler/plumber/database.rb
@@ -93,16 +93,15 @@ module Bundler
       # @note
       #   Requires network access.
       #
-      # @since 0.3.0
-      #
       def self.update!(options={})
         raise "Invalid option(s)" unless (options.keys - [:quiet]).empty?
         if File.directory?(USER_PATH)
           if File.directory?(File.join(USER_PATH, ".git"))
             Dir.chdir(USER_PATH) do
-              command = %w(git pull)
+              command = %w(git fetch --all)
+              command = %w(git reset --hard origin/master)
               command << '--quiet' if options[:quiet]
-              command << 'origin' << 'master'
+
               system *command
             end
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ module Helpers
   def expect_update_to_update_repo!
     expect(Bundler::Plumber::Database).
       to receive(:system).
-      with('git', 'pull', 'origin', 'master').
+      with('git', 'reset', '--hard', 'origin/master').
       and_call_original
   end
 


### PR DESCRIPTION
This change will ensure `bundler-leak` always updates to the latest changes of https://github.com/rubymem/ruby-mem-advisory-db

Since https://github.com/rubymem/ruby-mem-advisory-db is still in undergoing development, and recently I rewrote the commit history from it, this change will ensure users that already installed the gem avoid issues when updating the db.

