### PR TITLE
Fix update! database when :quiet option is true

### DIFF
--- a/lib/bundler/plumber/database.rb
+++ b/lib/bundler/plumber/database.rb
@@ -101,7 +101,7 @@ module Bundler
           if File.directory?(File.join(USER_PATH, ".git"))
             Dir.chdir(USER_PATH) do
               command = "git fetch --all; git reset --hard origin/master"
-              command << '--quiet' if options[:quiet]
+              command << ' --quiet' if options[:quiet]
 
               system *command
             end

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -41,14 +41,28 @@ describe Bundler::Plumber::Database do
       expect(File.directory?(mocked_user_path)).to be true
     end
 
-    it "should create the repo, then update it given multple successive calls." do
-      expect_update_to_clone_repo!
-      Bundler::Plumber::Database.update!(quiet: false)
-      expect(File.directory?(mocked_user_path)).to be true
+    context "when the :quiet option is false" do
+      it "should create the repo, then update it given multiple successive calls." do
+        expect_update_to_clone_repo!
+        Bundler::Plumber::Database.update!(quiet: false)
+        expect(File.directory?(mocked_user_path)).to be true
 
-      expect_update_to_update_repo!
-      Bundler::Plumber::Database.update!(quiet: false)
-      expect(File.directory?(mocked_user_path)).to be true
+        expect_update_to_update_repo!
+        Bundler::Plumber::Database.update!(quiet: false)
+        expect(File.directory?(mocked_user_path)).to be true
+      end
+    end
+
+    context "when the :quiet option is true" do
+      it "should create the repo, then update it given multiple successive calls." do
+        expect_update_to_clone_repo!
+        Bundler::Plumber::Database.update!(quiet: true)
+        expect(File.directory?(mocked_user_path)).to be true
+
+        expect_update_to_update_repo!
+        Bundler::Plumber::Database.update!(quiet: true)
+        expect(File.directory?(mocked_user_path)).to be true
+      end
     end
   end
 

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -55,11 +55,11 @@ describe Bundler::Plumber::Database do
 
     context "when the :quiet option is true" do
       it "should create the repo, then update it given multiple successive calls." do
-        expect_update_to_clone_repo!
+        expect_update_to_clone_repo!(quiet: true)
         Bundler::Plumber::Database.update!(quiet: true)
         expect(File.directory?(mocked_user_path)).to be true
 
-        expect_update_to_update_repo!
+        expect_update_to_update_repo!(quiet: true)
         Bundler::Plumber::Database.update!(quiet: true)
         expect(File.directory?(mocked_user_path)).to be true
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,17 +22,24 @@ module Helpers
     File.expand_path('../../tmp/ruby-mem-advisory-db', __FILE__)
   end
 
-  def expect_update_to_clone_repo!
+  def expect_update_to_clone_repo!(quiet: false)
+    with = ['git', 'clone']
+    with << '--quiet' if quiet
+    with << Bundler::Plumber::Database::VENDORED_PATH << mocked_user_path
+
     expect(Bundler::Plumber::Database).
       to receive(:system).
-      with('git', 'clone', Bundler::Plumber::Database::VENDORED_PATH, mocked_user_path).
+      with(*with).
       and_call_original
   end
 
-  def expect_update_to_update_repo!
+  def expect_update_to_update_repo!(quiet: false)
+    with = 'git fetch --all; git reset --hard origin/master'
+    with << " --quiet" if quiet
+
     expect(Bundler::Plumber::Database).
       to receive(:system).
-      with("git fetch --all; git reset --hard origin/master").
+      with(with).
       and_call_original
   end
 


### PR DESCRIPTION
Example of the problem:
```ruby
2) Bundler::Plumber::Database update! when the :quiet option is true should create the repo, then update it given multiple successive calls.
     Failure/Error: system *command

       #<Bundler::Plumber::Database (class)> received :system with unexpected arguments
         expected: ("git fetch --all; git reset --hard origin/master --quiet")
              got: ("git fetch --all; git reset --hard origin/master--quiet")
     # ./spec/database_spec.rb:63:in `block (4 levels) in <top (required)>'
```