### PR TITLE
Add ignore option

### DIFF
--- a/lib/bundler/plumber/advisory.rb
+++ b/lib/bundler/plumber/advisory.rb
@@ -20,14 +20,17 @@ require 'yaml'
 
 module Bundler
   module Plumber
-    class Advisory < Struct.new(:path,
-                                :id,
-                                :url,
-                                :title,
-                                :date,
-                                :description,
-                                :unaffected_versions,
-                                :patched_versions)
+    class Advisory < Struct.new(
+      :gem,
+      :path,
+      :id,
+      :url,
+      :title,
+      :date,
+      :description,
+      :unaffected_versions,
+      :patched_versions
+    )
 
       #
       # Loads the advisory from a YAML file.
@@ -54,6 +57,7 @@ module Bundler
         }
 
         return new(
+          data['gem'],
           path,
           id,
           data['url'],

--- a/lib/bundler/plumber/cli.rb
+++ b/lib/bundler/plumber/cli.rb
@@ -33,6 +33,7 @@ module Bundler
       desc 'check', 'Checks the Gemfile.lock for known memory leaks'
       method_option :quiet, :type => :boolean, :aliases => '-q'
       method_option :verbose, :type => :boolean, :aliases => '-v'
+      method_option :ignore, :type => :array, :aliases => '-i'
       method_option :update, :type => :boolean, :aliases => '-u'
 
       def check
@@ -41,7 +42,7 @@ module Bundler
         scanner    = Scanner.new
         leaky = false
 
-        scanner.scan do |result|
+        scanner.scan(ignore: options.ignore) do |result|
           leaky = true
 
           case result

--- a/lib/bundler/plumber/scanner.rb
+++ b/lib/bundler/plumber/scanner.rb
@@ -116,9 +116,7 @@ module Bundler
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
             gem_and_id = "#{advisory.gem}-#{advisory.id}"
-            unless ignore.include?(gem_and_id)
-              yield UnpatchedGem.new(gem,advisory)
-            end
+            yield UnpatchedGem.new(gem,advisory) unless ignore.include?(gem_and_id)
           end
         end
       end

--- a/lib/bundler/plumber/scanner.rb
+++ b/lib/bundler/plumber/scanner.rb
@@ -80,9 +80,6 @@ module Bundler
       def scan(options={},&block)
         return enum_for(__method__, options) unless block
 
-        ignore = Set[]
-        ignore += options[:ignore] if options[:ignore]
-
         scan_specs(options, &block)
 
         return self

--- a/lib/bundler/plumber/scanner.rb
+++ b/lib/bundler/plumber/scanner.rb
@@ -118,12 +118,10 @@ module Bundler
 
         @lockfile.specs.each do |gem|
           @database.check_gem(gem) do |advisory|
-
-            # TODO this logic should be modified for rubymem
-            #unless (ignore.include?(advisory.cve_id) || ignore.include?(advisory.osvdb_id))
-            #  yield UnpatchedGem.new(gem,advisory)
-            #end
-            yield UnpatchedGem.new(gem, advisory)
+            gem_and_id = "#{advisory.gem}-#{advisory.id}"
+            unless ignore.include?(gem_and_id)
+              yield UnpatchedGem.new(gem,advisory)
+            end
           end
         end
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -31,6 +31,23 @@ Solution: upgrade to (~>|>=) \d+\.\d+\.\d+(\.\d+)?(, (~>|>=) \d+\.\d+\.\d+(\.\d+
     end
   end
 
+  context "when auditing a bundle with ignored gems" do
+    let(:bundle)    { 'unpatched_gems' }
+    let(:directory) { File.join('spec','bundle', bundle) }
+
+    let(:command) do
+      File.expand_path(File.join(File.dirname(__FILE__),'..','bin','bundler-leak -i celluloid-670'))
+    end
+
+    subject do
+      Dir.chdir(directory) { sh(command, :fail => true) }
+    end
+
+    it "should not print advisory information for ignored gem" do
+      expect(subject).not_to include("Name: celluloid\nVersion: 0.17.0\n")
+    end
+  end
+
   describe "update" do
 
     let(:update_command) { "#{command} update" }

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -37,12 +37,12 @@ describe Scanner do
     end
 
     context "when the :ignore option is given" do
-      subject { scanner.scan(:ignore => ['OSVDB-89026']) }
+      subject { scanner.scan(:ignore => ['celluloid-670']) }
 
-      it "should ignore the specified advisories" do
+      it "should ignore the specified leaky gems" do
         ids = subject.map { |result| result.advisory.id }
 
-        expect(ids).not_to include('OSVDB-89026')
+        expect(ids).not_to include('670')
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/rubymem/bundler-leak/issues/18

Add `-i`, `--ignore` flag to ignore leaky gems 