### PR TITLE
Stop using `master` branch within library

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * [Issues](https://github.com/rubymem/bundler-leak/issues)
 * [Documentation](http://rubydoc.info/gems/bundler-leak/frames)
 * [Email](mailto:oss at ombulabs.com)
-* [![Build Status](https://travis-ci.org/rubymem/bundler-leak.svg?branch=master)](https://travis-ci.org/rubymem/bundler-leak)
+* [![Build Status](https://travis-ci.org/rubymem/bundler-leak.svg?branch=main)](https://travis-ci.org/rubymem/bundler-leak)
 * [![Code Climate](https://codeclimate.com/github/rubymem/bundler-leak.svg)](https://codeclimate.com/github/rubymem/bundler-leak)
 
 ## Description
@@ -45,15 +45,15 @@ Update the [ruby-mem-advisory-db] that `bundle leak` uses:
     $ bundle leak update
 
     cd data/ruby-mem-advisory-db
-    git pull origin master
+    git pull origin main
     remote: Enumerating objects: 14, done.
     remote: Counting objects: 100% (14/14), done.
     remote: Compressing objects: 100% (4/4), done.
     remote: Total 9 (delta 5), reused 7 (delta 4), pack-reused 0
     Unpacking objects: 100% (9/9), done.
     From github.com:rubymem/ruby-mem-advisory-db
-     * branch            master     -> FETCH_HEAD
-       3254525..c4fc78e  master     -> origin/master
+     * branch            main     -> FETCH_HEAD
+       3254525..c4fc78e  main     -> origin/main
     Updating 3254525..c4fc78e
     Fast-forward
      README.md                 | 68 ++++++++++++++++++++------------------------------------------------
@@ -118,6 +118,6 @@ along with bundler-leak.  If not, see <http://www.gnu.org/licenses/>.
 [ruby-mem-advisory-db]: https://github.com/rubymem/ruby-mem-advisory-db
 
 ## FastRuby.io
-![fastruby](https://github.com/rubymem/bundler-leak/raw/master/fastruby-logo.png)
+![fastruby](https://github.com/rubymem/bundler-leak/raw/main/fastruby-logo.png)
 
 `bundler-leak` is maintained and funded by FastRuby.io, inc. The names and logos for FastRuby.io are trademarks of FastRuby.io, inc.

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ namespace :db do
     timestamp = nil
 
     chdir 'data/ruby-mem-advisory-db' do
-      sh 'git', 'pull', 'origin', 'master'
+      sh 'git', 'pull', 'origin', 'main'
 
       File.open('../ruby-mem-advisory-db.ts','w') do |file|
         file.write Time.parse(`git log --pretty="%cd" -1`).utc

--- a/lib/bundler/plumber/database.rb
+++ b/lib/bundler/plumber/database.rb
@@ -100,7 +100,7 @@ module Bundler
         if File.directory?(USER_PATH)
           if File.directory?(File.join(USER_PATH, ".git"))
             Dir.chdir(USER_PATH) do
-              command = "git fetch --all; git reset --hard origin/master"
+              command = "git fetch --all; git reset --hard origin/main"
               command << ' --quiet' if options[:quiet]
 
               system *command

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ module Helpers
   end
 
   def expect_update_to_update_repo!(quiet: false)
-    with = 'git fetch --all; git reset --hard origin/master'
+    with = 'git fetch --all; git reset --hard origin/main'
     with << " --quiet" if quiet
 
     expect(Bundler::Plumber::Database).


### PR DESCRIPTION
Hey, 

This PR follows these guidelines: https://www.ombulabs.com/blog/inclusion/team/culture/removing-negative-words.html

We should start using the `main` branch in library and documentation.

Please check it out. 

Thanks! 