### PR TITLE
When using Psych v4+ (with default safe loading), permit `Date` class

### DIFF
--- a/lib/bundler/plumber/advisory.rb
+++ b/lib/bundler/plumber/advisory.rb
@@ -44,7 +44,12 @@ module Bundler
       #
       def self.load(path)
         id   = File.basename(path).chomp('.yml')
-        data = YAML.load_file(path)
+        data =
+          if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('4')
+            YAML.load_file(path, permitted_classes: [Date])
+          else
+            YAML.load_file(path)
+          end
 
         unless data.kind_of?(Hash)
           raise("advisory data in #{path.dump} was not a Hash")


### PR DESCRIPTION
[Ruby v3.1+ uses Psych v4+, which uses safe-loading by default for parsing YAML.](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/) Because of this, it's necessary to explicitly permit `Date` as a class that it can load.

---

Fixes #44.

---

I will abide by the [code of conduct](https://github.com/rubymem/bundler-leak/blob/9c61f8d90f36cce35c589fa77e83c8b1494784b6/code-of-conduct.md).